### PR TITLE
Support custom task note paths and fix task note sync regressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "obsidian-didasync",
             "version": "1.5.2",
             "license": "MIT",
+            "dependencies": {
+                "date-fns": "^2.30.0"
+            },
             "devDependencies": {
                 "@types/node": "^16.11.26",
                 "@typescript-eslint/eslint-plugin": "^5.29.0",
@@ -16,6 +19,14 @@
                 "obsidian": "latest",
                 "tslib": "2.4.0",
                 "typescript": "4.9.5"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.7",
+            "resolved": "https://mirrors.cloud.tencent.com/npm/@babel/runtime/-/runtime-7.29.7.tgz",
+            "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@codemirror/state": {
@@ -957,6 +968,22 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/date-fns": {
+            "version": "2.30.0",
+            "resolved": "https://mirrors.cloud.tencent.com/npm/date-fns/-/date-fns-2.30.0.tgz",
+            "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.21.0"
+            },
+            "engines": {
+                "node": ">=0.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/date-fns"
             }
         },
         "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "scripts": {
         "dev": "node esbuild.config.mjs",
         "build": "node esbuild.config.mjs production",
+        "test:task-note-context": "npx tsc --module commonjs --target ES2019 --esModuleInterop --outDir .tmp-test tests/taskNoteContext.test.ts src/taskNoteContext.ts src/taskNotePath.ts src/types.ts && node .tmp-test/tests/taskNoteContext.test.js",
+        "test:task-note-path": "npx tsc --module commonjs --target ES2019 --esModuleInterop --outDir .tmp-test tests/taskNotePath.test.ts src/taskNotePath.ts src/types.ts && node .tmp-test/tests/taskNotePath.test.js",
         "test:task-index": "rm -rf .tmp-test && ./node_modules/.bin/tsc --module commonjs --target ES2019 --esModuleInterop --outDir .tmp-test tests/taskIndex.test.ts src/taskIndex.ts && node .tmp-test/tests/taskIndex.test.js",
         "test:mcp": "node -e \"require('fs').rmSync('.tmp-test',{recursive:true,force:true}); require('fs').mkdirSync('.tmp-test',{recursive:true})\" && node -e \"require('esbuild').buildSync({entryPoints:['tests/mcpServerManager.test.ts','src/managers/McpServerManager.ts','src/types.ts'],outdir:'.tmp-test',platform:'node',format:'cjs',bundle:false})\" && node .tmp-test/tests/mcpServerManager.test.js",
         "test:repeat-cloud-authority": "node -e \"require('fs').rmSync('.tmp-test',{recursive:true,force:true}); require('fs').mkdirSync('.tmp-test',{recursive:true})\" && node -e \"require('esbuild').buildSync({entryPoints:['tests/repeatTaskCloudAuthority.test.ts','src/managers/SyncManager.ts','src/types.ts'],outdir:'.tmp-test',platform:'node',format:'cjs',bundle:false})\" && node .tmp-test/tests/repeatTaskCloudAuthority.test.js",
@@ -27,5 +29,8 @@
         "obsidian": "latest",
         "tslib": "2.4.0",
         "typescript": "4.9.5"
+    },
+    "dependencies": {
+        "date-fns": "^2.30.0"
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,7 +13,12 @@ export const DEFAULT_SETTINGS = {
     enableNativeTaskSync: true,
     taskNoteSyncTargetBlockHeader: "> [!todo]",
     taskNoteSyncFolder: "DidaSync",
-    taskNoteSyncFileNamePattern: "",
+    taskNoteSyncPathPatterns: {
+        day: "",
+        week: "",
+        month: "",
+        year: ""
+    },
     taskNoteSyncCreateNewFile: false,
     taskNoteSyncWeekStart: "monday",
     taskNoteSyncUseRemoteQuery: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -186,8 +186,9 @@ export default class DidaSyncPlugin extends Plugin {
         const legacySettings = this.settings as any;
         if (loadedSettings?.dailySyncTargetBlockHeader && !loadedSettings?.taskNoteSyncTargetBlockHeader) {
             this.settings.taskNoteSyncTargetBlockHeader = loadedSettings.dailySyncTargetBlockHeader;
-            delete legacySettings.dailySyncTargetBlockHeader;
         }
+        delete legacySettings.dailySyncTargetBlockHeader;
+        delete legacySettings.taskNoteSyncFileNamePattern;
         if (!this.settings.tasks) this.settings.tasks = [];
         this.settings.tasks.forEach(t => {
             if (t.content === undefined) t.content = "";
@@ -201,6 +202,14 @@ export default class DidaSyncPlugin extends Plugin {
         if (!Array.isArray(this.settings.hiddenProjectKeys)) this.settings.hiddenProjectKeys = [];
         if (!["all", "visible", "custom"].includes(this.settings.taskNoteSyncProjectScope)) this.settings.taskNoteSyncProjectScope = "all";
         if (!Array.isArray(this.settings.taskNoteSyncProjectKeys)) this.settings.taskNoteSyncProjectKeys = [];
+        if (!this.settings.taskNoteSyncPathPatterns || typeof this.settings.taskNoteSyncPathPatterns !== "object") {
+            this.settings.taskNoteSyncPathPatterns = { ...DEFAULT_SETTINGS.taskNoteSyncPathPatterns };
+        } else {
+            this.settings.taskNoteSyncPathPatterns = {
+                ...DEFAULT_SETTINGS.taskNoteSyncPathPatterns,
+                ...this.settings.taskNoteSyncPathPatterns
+            };
+        }
         if (!Array.isArray(this.settings.projectCatalog)) this.settings.projectCatalog = [];
         this.settings.projectCatalog = this.normalizeProjectCatalog(this.settings.projectCatalog);
         await this.ensureProjectCatalogFromTasks();
@@ -1063,6 +1072,7 @@ export default class DidaSyncPlugin extends Plugin {
             kind: task.kind || "TEXT",
             reminders: task.reminders || [],
             repeatFlag: task.repeatFlag || null,
+            priority: task.priority ?? 0,
             status: task.status || 0,
             completed: task.status === 2,
             completedTime: task.completedTime || null,

--- a/src/managers/TaskNoteSyncManager.ts
+++ b/src/managers/TaskNoteSyncManager.ts
@@ -1,6 +1,26 @@
 import { App, normalizePath, Notice, TFile } from "obsidian";
 import DidaSyncPlugin from "../main";
 import { formatTaskLineFromTask, parseTaskLine } from "../taskLineFormat";
+import {
+    resolveTaskNoteContextFromFrontmatter,
+    resolveTaskNoteContextFromLegacyDate,
+    resolveTaskNoteContextFromLegacyFileName,
+    resolveTaskNoteContextFromTitle,
+    TaskNoteResolvedContext
+} from "../taskNoteContext";
+import {
+    buildDefaultTaskNoteFileName,
+    buildTaskNoteRelativePath,
+    buildTaskNoteTargetFilePath,
+    ensureMarkdownExtension,
+    formatDateOnly,
+    getTaskNotePathPattern,
+    getTaskNoteWeekRange,
+    getTaskNoteWeekStem,
+    getTaskNoteWeekInfo,
+    parseDateOnly,
+    renderTaskNotePathPattern
+} from "../taskNotePath";
 import { DidaTask } from "../types";
 
 export type TaskNoteSyncRangeType = "day" | "week" | "month" | "year" | "custom";
@@ -16,6 +36,13 @@ export interface TaskNoteSyncOptions {
     createNewFile?: boolean;
     projectScope?: "all" | "visible" | "custom";
     projectKeys?: string[];
+}
+
+export interface TaskNoteSyncResolvedContext {
+    rangeType: TaskNoteSyncRangeType;
+    baseDate: string;
+    startDate: string;
+    endDate: string;
 }
 
 interface ParsedTaskBlock {
@@ -93,13 +120,32 @@ export class TaskNoteSyncManager {
     }
 
     buildInitialContent(range: TaskNoteSyncRange): string {
-        return `# ${this.getRangeTitle(range)}\n\n${this.plugin.settings.taskNoteSyncTargetBlockHeader}\n`;
+        return [
+            "---",
+            `didaSyncRangeType: ${range.type}`,
+            `didaSyncStartDate: ${range.startDate}`,
+            `didaSyncEndDate: ${range.endDate}`,
+            "---",
+            `# ${this.getRangeTitle(range)}`,
+            "",
+            this.plugin.settings.taskNoteSyncTargetBlockHeader,
+            ""
+        ].join("\n");
     }
 
     buildTargetFilePath(range: TaskNoteSyncRange): string {
-        const folder = normalizePath((this.plugin.settings.taskNoteSyncFolder || "DidaSync").trim());
-        const fileName = this.buildTargetFileName(range);
-        return folder ? normalizePath(`${folder}/${fileName}`) : fileName;
+        return buildTaskNoteTargetFilePath(range, {
+            rootFolder: this.plugin.settings.taskNoteSyncFolder || "DidaSync",
+            weekStart: this.plugin.settings.taskNoteSyncWeekStart || "monday",
+            pathPatterns: this.plugin.settings.taskNoteSyncPathPatterns
+        });
+    }
+
+    buildRelativeTargetPath(range: TaskNoteSyncRange): string {
+        return buildTaskNoteRelativePath(range, {
+            weekStart: this.plugin.settings.taskNoteSyncWeekStart || "monday",
+            pathPatterns: this.plugin.settings.taskNoteSyncPathPatterns
+        });
     }
 
     async buildUniqueTargetFilePath(range: TaskNoteSyncRange): Promise<string> {
@@ -116,11 +162,19 @@ export class TaskNoteSyncManager {
     }
 
     buildTargetFileName(range: TaskNoteSyncRange): string {
-        if (range.type === "day") return `${range.startDate}.md`;
-        if (range.type === "week") return `${this.getIsoWeekFileStem(range.startDate)}.md`;
-        if (range.type === "month") return `${range.startDate.slice(0, 7)}.md`;
-        if (range.type === "year") return `${range.startDate.slice(0, 4)}.md`;
-        return `${range.startDate}_to_${range.endDate}.md`;
+        return buildDefaultTaskNoteFileName(range, this.plugin.settings.taskNoteSyncWeekStart || "monday");
+    }
+
+    getPathPatternForRange(range: TaskNoteSyncRange): string {
+        return getTaskNotePathPattern(range.type, this.plugin.settings.taskNoteSyncPathPatterns);
+    }
+
+    renderPathPattern(range: TaskNoteSyncRange, pattern: string): string {
+        return renderTaskNotePathPattern(range, pattern, this.plugin.settings.taskNoteSyncWeekStart || "monday");
+    }
+
+    ensureMarkdownExtension(path: string): string {
+        return ensureMarkdownExtension(path);
     }
 
     async ensureMarkdownFile(path: string, initialContent: string): Promise<TFile> {
@@ -283,33 +337,34 @@ export class TaskNoteSyncManager {
         return this.normalizeTitle(text);
     }
 
-    async resolveTargetDate(file: TFile): Promise<string | null> {
-        const nameMatch = file.basename.match(/^(\d{4}-\d{2}-\d{2})/);
-        if (nameMatch) return nameMatch[1];
-
+    async resolveTargetContext(file: TFile): Promise<TaskNoteSyncResolvedContext | null> {
         const cache = this.app.metadataCache.getFileCache(file);
-        if (cache && cache.frontmatter) {
-            const rawDate = cache.frontmatter.date || cache.frontmatter.data;
-            if (rawDate) {
-                const d = new Date(rawDate);
-                if (!isNaN(d.getTime())) return this.formatDateOnly(d);
-            }
-        }
+        const frontmatterContext = resolveTaskNoteContextFromFrontmatter(cache?.frontmatter);
+        if (frontmatterContext) return this.toResolvedContext(frontmatterContext);
+
+        const content = await this.app.vault.cachedRead(file);
+        const titleContext = this.parseRangeContextFromContent(content);
+        if (titleContext) return titleContext;
+
+        const fileNameContext = resolveTaskNoteContextFromLegacyFileName(file.basename);
+        if (fileNameContext) return this.toResolvedContext(fileNameContext);
+
+        const legacyDateContext = resolveTaskNoteContextFromLegacyDate(cache?.frontmatter?.date || cache?.frontmatter?.data);
+        if (legacyDateContext) return this.toResolvedContext(legacyDateContext);
 
         return null;
+    }
+
+    async resolveTargetDate(file: TFile): Promise<string | null> {
+        const context = await this.resolveTargetContext(file);
+        return context ? context.baseDate : null;
     }
 
     createRange(type: TaskNoteSyncRangeType, baseDate: string, endDate?: string): TaskNoteSyncRange {
         const base = this.parseDateOnly(baseDate);
         if (type === "day") return { type, startDate: baseDate, endDate: baseDate };
         if (type === "week") {
-            const weekStartsOnSunday = this.plugin.settings.taskNoteSyncWeekStart === "sunday";
-            const day = weekStartsOnSunday ? base.getDay() : (base.getDay() || 7) - 1;
-            const start = new Date(base);
-            start.setDate(base.getDate() - day);
-            const end = new Date(start);
-            end.setDate(start.getDate() + 6);
-            return { type, startDate: this.formatDateOnly(start), endDate: this.formatDateOnly(end) };
+            return { type, ...getTaskNoteWeekRange(baseDate, this.plugin.settings.taskNoteSyncWeekStart || "monday") };
         }
         if (type === "month") {
             const start = new Date(base.getFullYear(), base.getMonth(), 1);
@@ -436,32 +491,42 @@ export class TaskNoteSyncManager {
 
     getRangeTitle(range: TaskNoteSyncRange): string {
         if (range.type === "day") return range.startDate;
-        if (range.type === "week") return this.getIsoWeekFileStem(range.startDate);
+        if (range.type === "week") return this.getWeekStem(range.startDate);
         if (range.type === "month") return range.startDate.slice(0, 7);
         if (range.type === "year") return range.startDate.slice(0, 4);
         return `${range.startDate} to ${range.endDate}`;
     }
 
-    getIsoWeekFileStem(dateStr: string): string {
-        const date = this.parseDateOnly(dateStr);
-        const utc = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-        const day = utc.getUTCDay() || 7;
-        utc.setUTCDate(utc.getUTCDate() + 4 - day);
-        const yearStart = new Date(Date.UTC(utc.getUTCFullYear(), 0, 1));
-        const week = Math.ceil((((utc.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
-        return `${utc.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
+    getWeekStem(dateStr: string): string {
+        return getTaskNoteWeekStem(dateStr, this.plugin.settings.taskNoteSyncWeekStart || "monday");
+    }
+
+    getWeekPatternInfo(dateStr: string): { year: number; week: number } {
+        return getTaskNoteWeekInfo(dateStr, this.plugin.settings.taskNoteSyncWeekStart || "monday");
     }
 
     parseDateOnly(dateStr: string): Date {
-        const [year, month, day] = dateStr.split("-").map(Number);
-        return new Date(year, month - 1, day);
+        return parseDateOnly(dateStr);
     }
 
     formatDateOnly(date: Date): string {
-        const y = date.getFullYear();
-        const m = String(date.getMonth() + 1).padStart(2, "0");
-        const d = String(date.getDate()).padStart(2, "0");
-        return `${y}-${m}-${d}`;
+        return formatDateOnly(date);
+    }
+
+    parseRangeContextFromContent(content: string): TaskNoteSyncResolvedContext | null {
+        const match = content.match(/^#\s+(.+)$/m);
+        if (!match) return null;
+        const context = resolveTaskNoteContextFromTitle(match[1].trim(), this.plugin.settings.taskNoteSyncWeekStart || "monday");
+        return context ? this.toResolvedContext(context) : null;
+    }
+
+    toResolvedContext(context: TaskNoteResolvedContext): TaskNoteSyncResolvedContext {
+        return {
+            rangeType: context.rangeType,
+            baseDate: context.baseDate,
+            startDate: context.startDate,
+            endDate: context.endDate
+        };
     }
 
     normalizeTitle(title: string): string {

--- a/src/modals/TaskNoteSyncModal.ts
+++ b/src/modals/TaskNoteSyncModal.ts
@@ -26,13 +26,14 @@ export class TaskNoteSyncModal extends Modal {
     async onOpen() {
         const today = this.plugin.taskNoteSyncManager.formatDateOnly(new Date());
         const targetFile = this.sourceFile || this.app.workspace.getActiveFile();
-        const targetDate = targetFile instanceof TFile
-            ? await this.plugin.taskNoteSyncManager.resolveTargetDate(targetFile)
+        const targetContext = targetFile instanceof TFile
+            ? await this.plugin.taskNoteSyncManager.resolveTargetContext(targetFile)
             : null;
 
-        this.baseDate = targetDate || today;
-        this.startDate = this.baseDate;
-        this.endDate = this.baseDate;
+        this.rangeType = targetContext?.rangeType || "day";
+        this.baseDate = targetContext?.baseDate || today;
+        this.startDate = targetContext?.startDate || this.baseDate;
+        this.endDate = targetContext?.endDate || this.baseDate;
         this.createNewFile = this.plugin.settings.taskNoteSyncCreateNewFile;
         this.projectScope = this.plugin.settings.taskNoteSyncProjectScope || "all";
         this.selectedProjectKeys = Array.isArray(this.plugin.settings.taskNoteSyncProjectKeys)

--- a/src/settings/views/sync-settings-view.ts
+++ b/src/settings/views/sync-settings-view.ts
@@ -103,7 +103,7 @@ export class SyncSettingsView extends AbstractSettingsView {
 
         new Setting(containerEl)
             .setName("写入区块")
-            .setDesc("任务会写入这个 Markdown 区块；目标笔记中没有该区块时会自动创建。")
+            .setDesc("任务会写入这个标题下；未找到时自动创建。支持普通标题或 callout，例如 > [!todo]。")
             .addText((text) => text
                 .setPlaceholder("输入目标区块标题")
                 .setValue(this.plugin.settings.taskNoteSyncTargetBlockHeader)
@@ -112,20 +112,74 @@ export class SyncSettingsView extends AbstractSettingsView {
                     await this.plugin.saveSettings();
                 }));
 
-        new Setting(containerEl)
+        const rootFolderSetting = new Setting(containerEl)
             .setName("笔记保存位置")
-            .setDesc("自动创建任务汇总笔记的文件夹。留空则保存到仓库根目录。")
+            .setDesc("自动创建任务汇总笔记的根文件夹。留空则保存到仓库根目录。")
             .addText((text) => text
                 .setPlaceholder("DidaSync")
                 .setValue(this.plugin.settings.taskNoteSyncFolder || "DidaSync")
                 .onChange(async (value) => {
                     this.plugin.settings.taskNoteSyncFolder = value;
                     await this.plugin.saveSettings();
+                    rootFolderPreview.setText(`当前预览：${this.getTaskNoteRootFolderPreview()}`);
                 }));
+        const rootFolderPreview = this.appendSettingPreview(rootFolderSetting, `当前预览：${this.getTaskNoteRootFolderPreview()}`);
+
+        const dayPathSetting = new Setting(containerEl)
+            .setName("日记路径模式")
+            .setDesc("相对根文件夹的路径，可包含子文件夹。")
+            .addText((text) => text
+                .setPlaceholder("YYYY/日记/YYYY-MM-DD")
+                .setValue(this.plugin.settings.taskNoteSyncPathPatterns?.day || "")
+                .onChange(async (value) => {
+                    this.plugin.settings.taskNoteSyncPathPatterns.day = value;
+                    await this.plugin.saveSettings();
+                    dayPathPreview.setText(this.getTaskNotePathPreviewText("day"));
+                }));
+        const dayPathPreview = this.appendSettingPreview(dayPathSetting, this.getTaskNotePathPreviewText("day"));
+
+        const weekPathSetting = new Setting(containerEl)
+            .setName("周记路径模式")
+            .setDesc("相对根文件夹的路径，可包含子文件夹。支持 gggg、ww，并跟随“一周开始于”设置。")
+            .addText((text) => text
+                .setPlaceholder("gggg/周记/[W]ww")
+                .setValue(this.plugin.settings.taskNoteSyncPathPatterns?.week || "")
+                .onChange(async (value) => {
+                    this.plugin.settings.taskNoteSyncPathPatterns.week = value;
+                    await this.plugin.saveSettings();
+                    weekPathPreview.setText(this.getTaskNotePathPreviewText("week"));
+                }));
+        const weekPathPreview = this.appendSettingPreview(weekPathSetting, this.getTaskNotePathPreviewText("week"));
+
+        const monthPathSetting = new Setting(containerEl)
+            .setName("月记路径模式")
+            .setDesc("相对根文件夹的路径，可包含子文件夹。")
+            .addText((text) => text
+                .setPlaceholder("YYYY/月记/YYYY-MM")
+                .setValue(this.plugin.settings.taskNoteSyncPathPatterns?.month || "")
+                .onChange(async (value) => {
+                    this.plugin.settings.taskNoteSyncPathPatterns.month = value;
+                    await this.plugin.saveSettings();
+                    monthPathPreview.setText(this.getTaskNotePathPreviewText("month"));
+                }));
+        const monthPathPreview = this.appendSettingPreview(monthPathSetting, this.getTaskNotePathPreviewText("month"));
+
+        const yearPathSetting = new Setting(containerEl)
+            .setName("年记路径模式")
+            .setDesc("相对根文件夹的路径。")
+            .addText((text) => text
+                .setPlaceholder("YYYY")
+                .setValue(this.plugin.settings.taskNoteSyncPathPatterns?.year || "")
+                .onChange(async (value) => {
+                    this.plugin.settings.taskNoteSyncPathPatterns.year = value;
+                    await this.plugin.saveSettings();
+                    yearPathPreview.setText(this.getTaskNotePathPreviewText("year"));
+                }));
+        const yearPathPreview = this.appendSettingPreview(yearPathSetting, this.getTaskNotePathPreviewText("year"));
 
         new Setting(containerEl)
             .setName("默认每次生成新笔记")
-            .setDesc("开启后每次同步都会生成新笔记；关闭后默认写入同名笔记，不存在时再创建。")
+            .setDesc("开启后每次都新建；关闭后优先写入同名笔记，不存在时再创建。")
             .addToggle((toggle) => toggle
                 .setValue(this.plugin.settings.taskNoteSyncCreateNewFile)
                 .onChange(async (value) => {
@@ -135,7 +189,7 @@ export class SyncSettingsView extends AbstractSettingsView {
 
         new Setting(containerEl)
             .setName("一周开始于")
-            .setDesc("决定“某周”同步范围的起止日期。")
+            .setDesc("影响周记的起止日期，以及 gggg / ww 的编号结果。")
             .addDropdown((dropdown) => dropdown
                 .addOption("monday", "周一")
                 .addOption("sunday", "周日")
@@ -143,11 +197,12 @@ export class SyncSettingsView extends AbstractSettingsView {
                 .onChange(async (value) => {
                     this.plugin.settings.taskNoteSyncWeekStart = value as "monday" | "sunday";
                     await this.plugin.saveSettings();
+                    weekPathPreview.setText(this.getTaskNotePathPreviewText("week"));
                 }));
 
         new Setting(containerEl)
             .setName("同步前查询远端任务")
-            .setDesc("开启后会按所选时间段向滴答清单查询最新任务；关闭后只使用本地缓存。")
+            .setDesc("开启后先按时间范围查询滴答最新任务；关闭后仅使用本地缓存。")
             .addToggle((toggle) => toggle
                 .setValue(this.plugin.settings.taskNoteSyncUseRemoteQuery)
                 .onChange(async (value) => {
@@ -188,31 +243,40 @@ export class SyncSettingsView extends AbstractSettingsView {
                     });
             });
 
-        new Setting(containerEl)
-            .setName("文件名规则")
-            .setDesc("预留给后续模板扩展。当前留空即可，插件会按任务范围自动命名。")
-            .addText((text) => text
-                .setPlaceholder("留空使用默认规则")
-                .setValue(this.plugin.settings.taskNoteSyncFileNamePattern || "")
-                .onChange(async (value) => {
-                    this.plugin.settings.taskNoteSyncFileNamePattern = value;
-                    await this.plugin.saveSettings();
-                }));
     }
 
     getTaskNoteProjectScopePreviewText(): string {
         const scope = this.plugin.settings.taskNoteSyncProjectScope || "all";
-        if (scope === "all") return "同步任务到笔记时默认使用全部清单。";
+        if (scope === "all") return "同步到笔记时默认包含全部清单。";
         if (scope === "visible") {
             const visibleCount = this.plugin.getAvailableProjectConfigs()
                 .filter((project) => this.plugin.settings.showArchivedProjects || !project.isArchived)
                 .filter((project) => this.plugin.isProjectVisible(project.id, project.name))
                 .length;
-            return `同步任务到笔记时默认使用侧边栏可见清单（${visibleCount} 个）。`;
+            return `同步到笔记时默认包含侧边栏可见清单（${visibleCount} 个）。`;
         }
         const keys = Array.isArray(this.plugin.settings.taskNoteSyncProjectKeys)
             ? this.plugin.settings.taskNoteSyncProjectKeys
             : [];
-        return `同步任务到笔记时默认使用自定义清单（已选择 ${keys.length} 个）。`;
+        return `同步到笔记时默认包含自定义清单（已选择 ${keys.length} 个）。`;
+    }
+
+    getTaskNoteRootFolderPreview(): string {
+        const rootFolder = (this.plugin.settings.taskNoteSyncFolder || "").trim();
+        return rootFolder || "/";
+    }
+
+    getTaskNotePathPreviewText(rangeType: "day" | "week" | "month" | "year"): string {
+        const exampleDate = "2026-01-19";
+        const range = this.plugin.taskNoteSyncManager.createRange(rangeType, exampleDate);
+        const preview = this.plugin.taskNoteSyncManager.buildRelativeTargetPath(range);
+        return `当前预览：${preview}`;
+    }
+
+    appendSettingPreview(setting: Setting, text: string): HTMLDivElement {
+        return setting.descEl.createDiv({
+            cls: "dida-settings-preview dida-settings-preview--muted",
+            text
+        });
     }
 }

--- a/src/taskNoteContext.ts
+++ b/src/taskNoteContext.ts
@@ -1,0 +1,153 @@
+import { getTaskNoteWeekRange, getTaskNoteWeekStem, TaskNoteSyncRangeType } from "./taskNotePath";
+
+export interface TaskNoteResolvedContext {
+    rangeType: TaskNoteSyncRangeType;
+    baseDate: string;
+    startDate: string;
+    endDate: string;
+}
+
+export function resolveTaskNoteContextFromFrontmatter(frontmatter: any): TaskNoteResolvedContext | null {
+    const rangeType = normalizeRangeType(frontmatter?.didaSyncRangeType);
+    const startDate = normalizeDateString(frontmatter?.didaSyncStartDate);
+    const endDate = normalizeDateString(frontmatter?.didaSyncEndDate);
+    if (!rangeType || !startDate || !endDate) return null;
+    return {
+        rangeType,
+        baseDate: getBaseDateForRange(rangeType, startDate),
+        startDate,
+        endDate
+    };
+}
+
+export function resolveTaskNoteContextFromTitle(
+    title: string,
+    weekStart: "monday" | "sunday"
+): TaskNoteResolvedContext | null {
+    const normalizedTitle = (title || "").trim();
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(normalizedTitle)) {
+        return {
+            rangeType: "day",
+            baseDate: normalizedTitle,
+            startDate: normalizedTitle,
+            endDate: normalizedTitle
+        };
+    }
+
+    const weekMatch = normalizedTitle.match(/^(\d{4})-W(\d{2})$/);
+    if (weekMatch) {
+        const year = Number(weekMatch[1]);
+        const week = Number(weekMatch[2]);
+        const startDate = resolveWeekStartFromStem(year, week, weekStart);
+        if (!startDate) return null;
+        const range = getTaskNoteWeekRange(startDate, weekStart);
+        return {
+            rangeType: "week",
+            baseDate: range.startDate,
+            startDate: range.startDate,
+            endDate: range.endDate
+        };
+    }
+
+    if (/^\d{4}-\d{2}$/.test(normalizedTitle)) {
+        const baseDate = `${normalizedTitle}-01`;
+        const [year, month] = normalizedTitle.split("-").map(Number);
+        const endDate = new Date(year, month, 0);
+        return {
+            rangeType: "month",
+            baseDate,
+            startDate: baseDate,
+            endDate: formatDateOnly(endDate)
+        };
+    }
+
+    if (/^\d{4}$/.test(normalizedTitle)) {
+        return {
+            rangeType: "year",
+            baseDate: `${normalizedTitle}-01-01`,
+            startDate: `${normalizedTitle}-01-01`,
+            endDate: `${normalizedTitle}-12-31`
+        };
+    }
+
+    const customMatch = normalizedTitle.match(/^(\d{4}-\d{2}-\d{2}) to (\d{4}-\d{2}-\d{2})$/);
+    if (customMatch) {
+        return {
+            rangeType: "custom",
+            baseDate: customMatch[1],
+            startDate: customMatch[1],
+            endDate: customMatch[2]
+        };
+    }
+
+    return null;
+}
+
+export function resolveTaskNoteContextFromLegacyDate(rawDate: unknown): TaskNoteResolvedContext | null {
+    if (!rawDate) return null;
+    const date = new Date(String(rawDate));
+    if (isNaN(date.getTime())) return null;
+    const dateOnly = formatDateOnly(date);
+    return {
+        rangeType: "day",
+        baseDate: dateOnly,
+        startDate: dateOnly,
+        endDate: dateOnly
+    };
+}
+
+export function resolveTaskNoteContextFromLegacyFileName(basename: string): TaskNoteResolvedContext | null {
+    const match = basename.match(/^(\d{4}-\d{2}-\d{2})/);
+    if (!match) return null;
+    return {
+        rangeType: "day",
+        baseDate: match[1],
+        startDate: match[1],
+        endDate: match[1]
+    };
+}
+
+export function getBaseDateForRange(type: TaskNoteSyncRangeType, startDate: string): string {
+    if (type === "custom") return startDate;
+    if (type === "year") return `${startDate.slice(0, 4)}-01-01`;
+    if (type === "month") return `${startDate.slice(0, 7)}-01`;
+    return startDate;
+}
+
+export function normalizeRangeType(value: unknown): TaskNoteSyncRangeType | null {
+    return typeof value === "string" && ["day", "week", "month", "year", "custom"].includes(value)
+        ? value as TaskNoteSyncRangeType
+        : null;
+}
+
+export function normalizeDateString(value: unknown): string | null {
+    return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value.trim()) ? value.trim() : null;
+}
+
+export function resolveWeekStartFromStem(
+    year: number,
+    week: number,
+    weekStart: "monday" | "sunday"
+): string | null {
+    if (!Number.isInteger(year) || !Number.isInteger(week) || week < 1 || week > 53) return null;
+    const searchStart = new Date(year - 1, 11, 20);
+    const searchEnd = new Date(year + 1, 0, 15);
+    const cursor = new Date(searchStart);
+    while (cursor <= searchEnd) {
+        const candidate = formatDateOnly(cursor);
+        const stem = getTaskNoteWeekStem(candidate, weekStart);
+        if (stem === `${year}-W${String(week).padStart(2, "0")}`) {
+            return getTaskNoteWeekRange(candidate, weekStart).startDate;
+        }
+        cursor.setDate(cursor.getDate() + 1);
+    }
+    return null;
+}
+
+function formatDateOnly(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, "0");
+    const d = String(date.getDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+}

--- a/src/taskNotePath.ts
+++ b/src/taskNotePath.ts
@@ -1,0 +1,188 @@
+import { endOfWeek, format, getWeek, getWeekYear, startOfWeek } from "date-fns";
+import { TaskNoteSyncPathPatterns } from "./types";
+
+export type TaskNoteSyncRangeType = "day" | "week" | "month" | "year" | "custom";
+
+export interface TaskNoteSyncRangeLike {
+    type: TaskNoteSyncRangeType;
+    startDate: string;
+    endDate: string;
+}
+
+export interface TaskNotePathContext {
+    rootFolder: string;
+    weekStart: "monday" | "sunday";
+    pathPatterns?: Partial<TaskNoteSyncPathPatterns> | null;
+}
+
+export function buildTaskNoteTargetFilePath(
+    range: TaskNoteSyncRangeLike,
+    context: TaskNotePathContext
+): string {
+    const folder = normalizeTaskNotePath((context.rootFolder || "").trim());
+    const relativePath = buildTaskNoteRelativePath(range, context);
+    return folder ? normalizeTaskNotePath(`${folder}/${relativePath}`) : relativePath;
+}
+
+export function buildTaskNoteRelativePath(
+    range: TaskNoteSyncRangeLike,
+    context: Pick<TaskNotePathContext, "weekStart" | "pathPatterns">
+): string {
+    const pattern = getTaskNotePathPattern(range.type, context.pathPatterns);
+    const relativePath = pattern
+        ? renderTaskNotePathPattern(range, pattern, context.weekStart)
+        : buildDefaultTaskNoteFileName(range, context.weekStart);
+    return ensureMarkdownExtension(relativePath);
+}
+
+export function getTaskNotePathPattern(
+    rangeType: TaskNoteSyncRangeType,
+    pathPatterns?: Partial<TaskNoteSyncPathPatterns> | null
+): string {
+    if (rangeType === "custom") return "";
+    if (!pathPatterns || typeof pathPatterns !== "object") return "";
+    return (pathPatterns[rangeType] || "").trim();
+}
+
+export function renderTaskNotePathPattern(
+    range: TaskNoteSyncRangeLike,
+    pattern: string,
+    weekStart: "monday" | "sunday"
+): string {
+    const anchorDate = parseDateOnly(range.startDate);
+    const weekInfo = range.type === "week" ? getTaskNoteWeekInfo(range.startDate, weekStart) : null;
+    const replacements = new Map<string, string>([
+        ["gggg", weekInfo ? String(weekInfo.year) : ""],
+        ["gg", weekInfo ? String(weekInfo.year).slice(-2) : ""],
+        ["ww", weekInfo ? String(weekInfo.week).padStart(2, "0") : ""],
+        ["w", weekInfo ? String(weekInfo.week) : ""],
+        ["YYYY", format(anchorDate, "yyyy")],
+        ["YY", format(anchorDate, "yy")],
+        ["MM", format(anchorDate, "MM")],
+        ["M", format(anchorDate, "M")],
+        ["DD", format(anchorDate, "dd")],
+        ["D", format(anchorDate, "d")]
+    ]);
+
+    const literalStore: string[] = [];
+    let rendered = normalizeTaskNotePath(pattern.trim()).replace(/\[([^\]]+)\]/g, (_, literal: string) => {
+        literalStore.push(literal);
+        return `\u0001${literalStore.length - 1}\u0002`;
+    });
+
+    rendered = replaceTaskNotePathTokens(rendered, replacements);
+
+    rendered = rendered.replace(/\u0001(\d+)\u0002/g, (_, index: string) => literalStore[Number(index)] || "");
+    return normalizeTaskNotePath(rendered);
+}
+
+export function buildDefaultTaskNoteFileName(
+    range: TaskNoteSyncRangeLike,
+    weekStart: "monday" | "sunday" = "monday"
+): string {
+    if (range.type === "day") return `${range.startDate}.md`;
+    if (range.type === "week") return `${getTaskNoteWeekStem(range.startDate, weekStart)}.md`;
+    if (range.type === "month") return `${range.startDate.slice(0, 7)}.md`;
+    if (range.type === "year") return `${range.startDate.slice(0, 4)}.md`;
+    return `${range.startDate}_to_${range.endDate}.md`;
+}
+
+export function ensureMarkdownExtension(path: string): string {
+    const trimmed = normalizeTaskNotePath((path || "").trim());
+    if (!trimmed) return "Untitled.md";
+    return trimmed.toLowerCase().endsWith(".md") ? trimmed : `${trimmed}.md`;
+}
+
+export function getTaskNoteWeekInfo(
+    dateStr: string,
+    weekStart: "monday" | "sunday"
+): { year: number; week: number } {
+    const date = parseDateOnly(dateStr);
+    const options = getTaskNoteWeekOptions(weekStart);
+    return {
+        year: getWeekYear(date, options),
+        week: getWeek(date, options)
+    };
+}
+
+export function getTaskNoteWeekStem(
+    dateStr: string,
+    weekStart: "monday" | "sunday"
+): string {
+    const weekInfo = getTaskNoteWeekInfo(dateStr, weekStart);
+    return `${weekInfo.year}-W${String(weekInfo.week).padStart(2, "0")}`;
+}
+
+export function getTaskNoteWeekRange(
+    dateStr: string,
+    weekStart: "monday" | "sunday"
+): { startDate: string; endDate: string } {
+    const date = parseDateOnly(dateStr);
+    const options = getTaskNoteWeekOptions(weekStart);
+    return {
+        startDate: formatDateOnly(startOfWeek(date, options)),
+        endDate: formatDateOnly(endOfWeek(date, options))
+    };
+}
+
+export function getTaskNoteWeekOptions(weekStart: "monday" | "sunday"): { weekStartsOn: 0 | 1; firstWeekContainsDate: 1 | 4 } {
+    return weekStart === "sunday"
+        ? { weekStartsOn: 0, firstWeekContainsDate: 1 }
+        : { weekStartsOn: 1, firstWeekContainsDate: 4 };
+}
+
+export function parseDateOnly(dateStr: string): Date {
+    const [year, month, day] = dateStr.split("-").map(Number);
+    return new Date(year, month - 1, day);
+}
+
+export function formatDateOnly(date: Date): string {
+    return format(date, "yyyy-MM-dd");
+}
+
+function normalizeTaskNotePath(value: string): string {
+    return (value || "")
+        .replace(/\\/g, "/")
+        .replace(/\/{2,}/g, "/")
+        .replace(/^\.\//, "")
+        .trim();
+}
+
+function replaceTaskNotePathTokens(input: string, replacements: Map<string, string>): string {
+    const tokens = ["gggg", "YYYY", "ww", "MM", "DD", "gg", "YY", "M", "D", "w"];
+    let result = "";
+
+    for (let index = 0; index < input.length;) {
+        const token = tokens.find((candidate) =>
+            input.startsWith(candidate, index) && isTaskNoteTokenBoundary(input, index, candidate, tokens)
+        );
+        if (!token) {
+            result += input[index];
+            index += 1;
+            continue;
+        }
+        result += replacements.get(token) || "";
+        index += token.length;
+    }
+
+    return result;
+}
+
+function isTaskNoteTokenBoundary(input: string, start: number, token: string, tokens: string[]): boolean {
+    const end = start + token.length;
+    const prevChar = start > 0 ? input[start - 1] : "";
+    const nextChar = end < input.length ? input[end] : "";
+
+    const prevBlocked = isAsciiLetter(prevChar) && !tokens.some((candidate) => {
+        const candidateStart = start - candidate.length;
+        return candidateStart >= 0 && input.startsWith(candidate, candidateStart);
+    });
+    if (prevBlocked) return false;
+
+    const nextBlocked = isAsciiLetter(nextChar) && !tokens.some((candidate) => input.startsWith(candidate, end));
+    return !nextBlocked;
+}
+
+function isAsciiLetter(char: string): boolean {
+    return /^[A-Za-z]$/.test(char);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,13 @@ export interface PomodoroSettings {
     totalFocusMinutes: number;
 }
 
+export interface TaskNoteSyncPathPatterns {
+    day: string;
+    week: string;
+    month: string;
+    year: string;
+}
+
 export interface DidaSyncSettings {
     clientId: string;
     clientSecret: string;
@@ -118,7 +125,7 @@ export interface DidaSyncSettings {
     // Task note sync settings
     taskNoteSyncTargetBlockHeader: string;
     taskNoteSyncFolder: string;
-    taskNoteSyncFileNamePattern: string;
+    taskNoteSyncPathPatterns: TaskNoteSyncPathPatterns;
     taskNoteSyncCreateNewFile: boolean;
     taskNoteSyncWeekStart: "monday" | "sunday";
     taskNoteSyncUseRemoteQuery: boolean;
@@ -181,7 +188,12 @@ export const DEFAULT_SETTINGS: DidaSyncSettings = {
     enableNativeTaskSync: true,
     taskNoteSyncTargetBlockHeader: "> [!todo]",
     taskNoteSyncFolder: "DidaSync",
-    taskNoteSyncFileNamePattern: "",
+    taskNoteSyncPathPatterns: {
+        day: "",
+        week: "",
+        month: "",
+        year: ""
+    },
     taskNoteSyncCreateNewFile: false,
     taskNoteSyncWeekStart: "monday",
     taskNoteSyncUseRemoteQuery: true,

--- a/styles.css
+++ b/styles.css
@@ -306,6 +306,16 @@
     color: #0066cc;
 }
 
+.dida-settings-preview {
+    margin-top: 4px;
+    font-size: 12px;
+    line-height: 1.45;
+}
+
+.dida-settings-preview--muted {
+    color: var(--text-muted);
+}
+
 .dida-settings-config {
     margin: 10px 0;
 }

--- a/tests/taskNoteContext.test.ts
+++ b/tests/taskNoteContext.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import {
+    resolveTaskNoteContextFromFrontmatter,
+    resolveTaskNoteContextFromLegacyDate,
+    resolveTaskNoteContextFromLegacyFileName,
+    resolveTaskNoteContextFromTitle
+} from "../src/taskNoteContext";
+
+{
+    const context = resolveTaskNoteContextFromFrontmatter({
+        didaSyncRangeType: "week",
+        didaSyncStartDate: "2025-12-29",
+        didaSyncEndDate: "2026-01-04"
+    });
+    assert.deepEqual(context, {
+        rangeType: "week",
+        baseDate: "2025-12-29",
+        startDate: "2025-12-29",
+        endDate: "2026-01-04"
+    });
+}
+
+{
+    const context = resolveTaskNoteContextFromTitle("2026-W01", "monday");
+    assert.deepEqual(context, {
+        rangeType: "week",
+        baseDate: "2025-12-29",
+        startDate: "2025-12-29",
+        endDate: "2026-01-04"
+    });
+}
+
+{
+    const context = resolveTaskNoteContextFromTitle("2026-06-01 to 2026-06-30", "monday");
+    assert.deepEqual(context, {
+        rangeType: "custom",
+        baseDate: "2026-06-01",
+        startDate: "2026-06-01",
+        endDate: "2026-06-30"
+    });
+}
+
+{
+    const context = resolveTaskNoteContextFromTitle("2026-06", "monday");
+    assert.deepEqual(context, {
+        rangeType: "month",
+        baseDate: "2026-06-01",
+        startDate: "2026-06-01",
+        endDate: "2026-06-30"
+    });
+}
+
+{
+    const context = resolveTaskNoteContextFromLegacyFileName("2026-06-16");
+    assert.deepEqual(context, {
+        rangeType: "day",
+        baseDate: "2026-06-16",
+        startDate: "2026-06-16",
+        endDate: "2026-06-16"
+    });
+}
+
+{
+    const context = resolveTaskNoteContextFromLegacyDate("2026-06-16T09:00:00+08:00");
+    assert.deepEqual(context, {
+        rangeType: "day",
+        baseDate: "2026-06-16",
+        startDate: "2026-06-16",
+        endDate: "2026-06-16"
+    });
+}
+
+console.log("taskNoteContext tests passed");

--- a/tests/taskNotePath.test.ts
+++ b/tests/taskNotePath.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import {
+    buildDefaultTaskNoteFileName,
+    buildTaskNoteRelativePath,
+    buildTaskNoteTargetFilePath,
+    getTaskNoteWeekInfo,
+    getTaskNoteWeekRange,
+    getTaskNoteWeekStem
+} from "../src/taskNotePath";
+
+{
+    const path = buildTaskNoteTargetFilePath(
+        {
+            type: "day",
+            startDate: "2026-06-16",
+            endDate: "2026-06-16"
+        },
+        {
+            rootFolder: "Life",
+            weekStart: "monday",
+            pathPatterns: {
+                day: "YYYY/日记/YYYY-MM-DD"
+            }
+        }
+    );
+    assert.equal(path, "Life/2026/日记/2026-06-16.md");
+}
+
+{
+    const weekRange = getTaskNoteWeekRange("2026-01-04", "sunday");
+    assert.deepEqual(weekRange, {
+        startDate: "2026-01-04",
+        endDate: "2026-01-10"
+    });
+
+    const weekInfo = getTaskNoteWeekInfo("2026-01-04", "sunday");
+    assert.deepEqual(weekInfo, {
+        year: 2026,
+        week: 2
+    });
+}
+
+{
+    const crossYearRange = getTaskNoteWeekRange("2025-12-29", "monday");
+    assert.deepEqual(crossYearRange, {
+        startDate: "2025-12-29",
+        endDate: "2026-01-04"
+    });
+
+    assert.equal(getTaskNoteWeekStem("2025-12-29", "monday"), "2026-W01");
+    assert.equal(
+        buildDefaultTaskNoteFileName(
+            { type: "week", startDate: "2025-12-29", endDate: "2026-01-04" },
+            "monday"
+        ),
+        "2026-W01.md"
+    );
+    assert.equal(
+        buildTaskNoteRelativePath(
+            {
+                type: "week",
+                startDate: "2025-12-29",
+                endDate: "2026-01-04"
+            },
+            {
+                weekStart: "monday",
+                pathPatterns: {
+                    week: "gggg/周记/[W]ww"
+                }
+            }
+        ),
+        "2026/周记/W01.md"
+    );
+}
+
+{
+    const sundayRelative = buildTaskNoteRelativePath(
+        {
+            type: "week",
+            startDate: "2026-01-04",
+            endDate: "2026-01-10"
+        },
+        {
+            weekStart: "sunday",
+            pathPatterns: {
+                week: "gggg/周记/[W]ww"
+            }
+        }
+    );
+
+    assert.equal(sundayRelative, "2026/周记/W02.md");
+    assert.equal(
+        buildDefaultTaskNoteFileName(
+            { type: "week", startDate: "2026-01-04", endDate: "2026-01-10" },
+            "sunday"
+        ),
+        "2026-W02.md"
+    );
+}
+
+{
+    const monthRelative = buildTaskNoteRelativePath(
+        {
+            type: "month",
+            startDate: "2026-01-01",
+            endDate: "2026-01-31"
+        },
+        {
+            weekStart: "monday",
+            pathPatterns: {
+                month: "YYYY/月记/YYYY-MM"
+            }
+        }
+    );
+
+    assert.equal(monthRelative, "2026/月记/2026-01.md");
+}
+
+{
+    const customRelative = buildTaskNoteRelativePath(
+        {
+            type: "custom",
+            startDate: "2026-06-01",
+            endDate: "2026-06-30"
+        },
+        {
+            weekStart: "monday",
+            pathPatterns: {
+                day: "YYYY/日记/YYYY-MM-DD",
+                week: "gggg/周记/[W]ww",
+                month: "YYYY/月记/YYYY-MM",
+                year: "YYYY"
+            }
+        }
+    );
+    assert.equal(customRelative, "2026-06-01_to_2026-06-30.md");
+}
+
+{
+    const path = buildTaskNoteTargetFilePath(
+        {
+            type: "day",
+            startDate: "2026-05-29",
+            endDate: "2026-05-29"
+        },
+        {
+            rootFolder: "Documents",
+            weekStart: "monday",
+            pathPatterns: {
+                day: "Dailynote/YYYY-MM-DD"
+            }
+        }
+    );
+    assert.equal(path, "Documents/Dailynote/2026-05-29.md");
+}
+
+console.log("taskNotePath tests passed");


### PR DESCRIPTION
## Summary
- add configurable task note path patterns with shared path rendering helpers and settings previews
- restore task note sync context resolution from frontmatter, titles, and legacy note metadata
- fix related regressions including legacy block header migration and path/template edge cases

## Testing
- npm.cmd run test:task-note-path
- npm.cmd run test:task-note-context
- npm.cmd run build

Closes #13